### PR TITLE
map to develop

### DIFF
--- a/app/src/main/java/com/example/capdex/data/location/LocationService.kt
+++ b/app/src/main/java/com/example/capdex/data/location/LocationService.kt
@@ -4,10 +4,10 @@ import android.Manifest
 import android.content.Context
 import android.content.pm.PackageManager
 import android.location.Location
+import android.os.Build
 import android.os.Looper
 import android.util.Log
 import androidx.core.app.ActivityCompat
-import com.example.capdex.data.model.Localizacao
 import com.example.capdex.data.repository.EmbarRepository
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationCallback
@@ -15,42 +15,38 @@ import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationResult
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.storage.FirebaseStorage
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import java.util.Date
 import javax.inject.Inject
 
-class LocationService @Inject constructor(
-    private val context: Context,
-    private val embarRepository: EmbarRepository
+class LocationService @Inject constructor( // Adicione @Inject aqui
+    @ApplicationContext private val context: Context, // Use @ApplicationContext para o Contexto
+    private val embarRepository: EmbarRepository // Injetar EmbarRepository
 ) {
     private val fusedLocationClient: FusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(context)
+    private val firestore = FirebaseFirestore.getInstance()
+    private val storage = FirebaseStorage.getInstance()
     private val coroutineScope = CoroutineScope(Dispatchers.IO)
 
-    private val locationRequest = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 10000) // Intervalo de 10 segundos
-        .setMinUpdateIntervalMillis(5000) // Pelo menos a cada 5 segundos
+    private val locationRequest = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 10000)
+        .setMinUpdateIntervalMillis(5000)
         .build()
 
     private var onLocationUpdate: ((Location) -> Unit)? = null
-    private var activeEmbarcacaoId: String? = null // ID da embarcação ativa
 
     private val locationCallback = object : LocationCallback() {
         override fun onLocationResult(locationResult: LocationResult) {
             locationResult.lastLocation?.let { location ->
                 onLocationUpdate?.invoke(location)
                 Log.d("LocationService", "Nova localização recebida: $location")
-
-                // Verifica se há uma embarcação ativa e se ela está em movimento
-                activeEmbarcacaoId?.let { embarcacaoId ->
-                    if (isMoving(location)) {
-                        coroutineScope.launch {
-                            saveLocationForEmbarcacao(embarcacaoId, location)
-                        }
-                    } else {
-                        Log.d("LocationService", "Embarcação $embarcacaoId não está em movimento, localização não será salva.")
-                    }
-                } ?: run {
-                    Log.w("LocationService", "Nenhuma embarcação ativa definida para salvar localização.")
+                coroutineScope.launch {
+                    saveLocationToFirebase(location)
                 }
             }
         }
@@ -60,22 +56,18 @@ class LocationService @Inject constructor(
         onLocationUpdate = listener
     }
 
-    // Adicione o ID da embarcação ao iniciar as atualizações
-    fun startLocationUpdates(embarcacaoId: String) {
-        this.activeEmbarcacaoId = embarcacaoId
+    fun startLocationUpdates() {
         if (ActivityCompat.checkSelfPermission(
                 context,
                 Manifest.permission.ACCESS_FINE_LOCATION
             ) == PackageManager.PERMISSION_GRANTED
         ) {
-            Log.d("LocationService", "Iniciando atualizações de localização para embarcação: $embarcacaoId")
+            Log.d("LocationService", "Iniciando atualizações de localização")
             fusedLocationClient.requestLocationUpdates(
                 locationRequest,
                 locationCallback,
                 Looper.getMainLooper()
             )
-        } else {
-            Log.e("LocationService", "Permissão de localização não concedida. Não foi possível iniciar atualizações.")
         }
     }
 
@@ -83,29 +75,38 @@ class LocationService @Inject constructor(
         Log.d("LocationService", "Parando atualizações de localização")
         fusedLocationClient.removeLocationUpdates(locationCallback)
         onLocationUpdate = null
-        activeEmbarcacaoId = null
     }
 
-    private fun isMoving(location: Location): Boolean {
-        return location.speed > 0.5 // m/s
-    }
-
-    private suspend fun saveLocationForEmbarcacao(embarcacaoId: String, location: Location) {
+    private suspend fun saveLocationToFirebase(location: Location) {
         try {
-            Log.d("LocationService", "Salvando localização para embarcação $embarcacaoId: $location")
+            Log.d("LocationService", "Salvando localização no Firebase: $location")
+            val deviceModel = Build.MODEL
 
-            val localizacaoData = Localizacao(
-                latitude = location.latitude,
-                longitude = location.longitude,
-                timestamp = System.currentTimeMillis(),
-                accuracy = location.accuracy.toDouble(),
-                speed = location.speed.toDouble()
+            val locationData = hashMapOf(
+                "deviceModel" to deviceModel, // Adicionando o modelo do dispositivo
+                "latitude" to location.latitude,
+                "longitude" to location.longitude,
+                "timestamp" to Date(),
+                "accuracy" to location.accuracy,
+                "speed" to location.speed
             )
 
-            embarRepository.addLocalizacao(embarcacaoId, localizacaoData)
+            // Salvar no Firestore
+            firestore.collection("locations")
+                .document()
+                .set(locationData)
+                .await()
 
+            // Salvar no Storage como backup
+            val locationJson = locationData.toString()
+            val storageRef = storage.reference
+                .child("locations")
+                .child("${Date().time}.json")
+
+            storageRef.putBytes(locationJson.toByteArray()).await()
         } catch (e: Exception) {
-            Log.e("LocationService", "Erro ao salvar localização para embarcação $embarcacaoId", e)
+            Log.e("LocationService", "Erro ao salvar localização no Firebase", e)
+            e.printStackTrace()
         }
     }
 }

--- a/app/src/main/java/com/example/capdex/ui/map/MapPreviewScreen.kt
+++ b/app/src/main/java/com/example/capdex/ui/map/MapPreviewScreen.kt
@@ -3,25 +3,40 @@ package com.example.capdex.ui.map
 import android.Manifest
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.LatLng
-import com.google.maps.android.compose.*
+import com.google.maps.android.compose.GoogleMap
+import com.google.maps.android.compose.MapProperties
+import com.google.maps.android.compose.MarkerInfoWindow
+import com.google.maps.android.compose.rememberCameraPositionState
+import com.google.maps.android.compose.rememberMarkerState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MapPreviewScreen(
     navController: NavController,
     isProprietario: Boolean,
-    mapViewModel: MapViewModel = viewModel()
 ) {
+
+    val mapViewModel: MapViewModel = hiltViewModel()
     val locationPermissionGranted by mapViewModel.locationPermissionGranted.collectAsState()
     val currentLocation by mapViewModel.currentLocation.collectAsState()
     val cameraPositionState = rememberCameraPositionState()

--- a/app/src/main/java/com/example/capdex/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/example/capdex/ui/map/MapViewModel.kt
@@ -1,9 +1,8 @@
 package com.example.capdex.ui.map
 
-import android.app.Application
 import android.location.Location
 import android.util.Log
-import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.ViewModel
 import com.example.capdex.data.location.LocationService
 import com.google.android.gms.maps.model.LatLng
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -14,43 +13,33 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MapViewModel @Inject constructor(
-    application: Application,
     private val locationService: LocationService
-) : AndroidViewModel(application) {
+) : ViewModel() {
 
-    val defaultLocation = LatLng(-23.55052, -46.633308) // São Paulo, Brasil
+    val defaultLocation = com.google.android.gms.maps.model.LatLng(-23.55052, -46.633308)
+
     private val _currentLocation = MutableStateFlow<LatLng?>(null)
     val currentLocation: StateFlow<LatLng?> = _currentLocation
 
     private val _locationPermissionGranted = MutableStateFlow(false)
     val locationPermissionGranted: StateFlow<Boolean> = _locationPermissionGranted.asStateFlow()
 
-    private val _activeEmbarcacaoId = MutableStateFlow<String?>("ID_DA_EMBARCACÃO_ATIVA_AQUI")
-
-    init {
-        locationService.setOnLocationUpdateListener { location ->
-            updateLocation(location)
-        }
-    }
-
-    private fun startLocationUpdates() {
+    fun startLocationUpdates() {
         Log.d("MapViewModel", "startLocationUpdates chamado. Permissão concedida: ${_locationPermissionGranted.value}")
         if (_locationPermissionGranted.value) {
-            _activeEmbarcacaoId.value?.let { embarcacaoId ->
-                Log.d("MapViewModel", "Iniciando LocationService para embarcação: $embarcacaoId")
-                locationService.startLocationUpdates(embarcacaoId)
-            } ?: run {
-                Log.w("MapViewModel", "Não foi possível iniciar atualizações: ID da embarcação ativa não definido.")
+            locationService.setOnLocationUpdateListener { location ->
+                updateLocation(location)
             }
+            locationService.startLocationUpdates()
         }
     }
 
-    private fun stopLocationUpdates() {
-        Log.d("MapViewModel", "stopLocationUpdates chamado")
+    fun stopLocationUpdates() {
+        Log.d("MapViewModel", "Parando atualizações")
         locationService.stopLocationUpdates()
     }
 
-    private fun updateLocation(location: Location) {
+    fun updateLocation(location: Location) {
         _currentLocation.value = LatLng(location.latitude, location.longitude)
     }
 


### PR DESCRIPTION
Refactor: Ajusta injeção de dependência e lógica de atualização de localização

Este commit realiza as seguintes alterações:

- **MapViewModel:**
    - Alterado de `AndroidViewModel` para `ViewModel`, removendo a dependência direta do `ApplicationContext`.
    - A responsabilidade de iniciar e parar as atualizações de localização foi movida para o `MapViewModel`.
    - A lógica de atualização da localização no ViewModel agora é acionada por um listener no `LocationService`.
    - O `activeEmbarcacaoId` foi removido, pois a lógica de qual embarcação está ativa será gerenciada em outro local.

- **LocationService:**
    - Adicionada a anotação `@Inject` ao construtor e `@ApplicationContext` para o `Context`, seguindo as melhores práticas de injeção de dependência com Hilt.
    - Removida a lógica de `activeEmbarcacaoId` e o parâmetro `embarcacaoId` de `startLocationUpdates`.
    - Removida a verificação `isMoving` antes de salvar a localização.
    - A função `saveLocationForEmbarcacao` foi renomeada para `saveLocationToFirebase` e agora salva os dados de localização no Firestore e no Storage, incluindo o modelo do dispositivo.

- **MapPreviewScreen:**
    - O `MapViewModel` agora é obtido usando `hiltViewModel()`.